### PR TITLE
fix: new users would fail to link their valorant account

### DIFF
--- a/src/commands/valorant/rankRole.ts
+++ b/src/commands/valorant/rankRole.ts
@@ -75,7 +75,8 @@ async function linkCommand(interaction: ModChatInputCommandInteraction) {
 	// Saves the account information to the valorant config
 	const newValorantConfig = await valorantConfigSchema.findOneAndUpdate(
 		{ userID: interaction.user.id },
-		{ puuid: PUUID }
+		{ puuid: PUUID },
+		{ upsert: true, new: true }
 	);
 	if (!newValorantConfig) {
 		interaction.editReply({

--- a/test/commands/valorant/rankRole.test.ts
+++ b/test/commands/valorant/rankRole.test.ts
@@ -84,7 +84,8 @@ describe('/valorant', () => {
 			await command.execute(interaction);
 			expect(mockValorantUpdate).toHaveBeenCalledWith(
 				{ userID: 'user-123' },
-				{ puuid: 'test-puuid-abc' }
+				{ puuid: 'test-puuid-abc' },
+				{ upsert: true, new: true }
 			);
 			const calls = (interaction.editReply as jest.Mock).mock.calls;
 			const lastEmbed = calls[calls.length - 1][0].embeds?.[0];


### PR DESCRIPTION
New users (those who didn't have an entry in valorantconfigs table) would recieve an error message when trying to link their account

The old pattern would check and create a new entry anytime they ran the command. This new pattern doesn't do this, and relies on upserts (which I had forgotten)